### PR TITLE
Fix for Disyplay Notification

### DIFF
--- a/harbour-whisperfish-message.conf
+++ b/harbour-whisperfish-message.conf
@@ -4,5 +4,6 @@ urgency=2
 x-nemo-preview-icon=/usr/share/harbour-whisperfish/icons/86x86/harbour-whisperfish-blue.png
 x-nemo-user-removable=true
 x-nemo-feedback=chat,chat_exists
+x-nemo-display-on=true
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false


### PR DESCRIPTION
Because in E.A. release 2.1.4.13 , whisperfish dont wakeup device when screen ist "black